### PR TITLE
Features/uncid 146 user login disable

### DIFF
--- a/hid_auth.admin.inc
+++ b/hid_auth.admin.inc
@@ -1,0 +1,12 @@
+<?php
+
+function hid_auth_configpage($form, &$form_state) {
+  $form['hid_auth_login_enabled'] = array(
+    '#type'           => 'checkbox',
+    '#title'          => t('Enable Drupal login page'),
+    '#default_value'  => variable_get('hid_auth_login_enabled', FALSE),
+    '#description'    => t('The user login page (/user/login) is disabled automatically by this module. Checking this option will allow users to login to Drupal directly.'),
+  );
+
+  return system_settings_form($form);
+}

--- a/hid_auth.module
+++ b/hid_auth.module
@@ -11,7 +11,10 @@ include_once 'hid_auth.features.inc';
  */
 function hid_auth_menu_alter(&$items) {
   // Disable the user registration page for all users.
-  $items['user/register']['access callback'] = FALSE;
+  $items['user/register']['access callback'] = 'hid_auth_user_register_access';
+
+  // Disable the user registration page for all users.
+  $items['user/password']['page callback'] = 'hid_auth_user_pass';
 
   // Disable the user login page if disabled.
   $items['user']['page callback'] = 'hid_auth_user_page';
@@ -203,6 +206,19 @@ function hid_auth_user_is_anonymous() {
 }
 
 /**
+ * Access callback function to replace user_register_access(). If logins are not
+ * permitted and the user is not logged in, deny the user access. If the user is
+ * logged in, use the default user_register_access() callback.
+ */
+function hid_auth_user_register_access() {
+  $login_enabled = variable_get('hid_auth_login_enabled', FALSE);
+  if ($login_enabled) {
+    return user_register_access();
+  }
+  return FALSE;
+}
+
+/**
  * Callback function to replace user_page(). If logins are not permitted and
  * the user is not logged in, deny the user access. If the user is logged in,
  * display their user page.
@@ -215,4 +231,18 @@ function hid_auth_user_page() {
     return user_page();
   }
   drupal_access_denied();
+}
+
+/**
+ * Callback function to replace user_pass(). If logins are not permitted and
+ * the user is not logged in, deny the user access.
+ */
+function hid_auth_user_pass($form_id) {
+  $login_enabled = variable_get('hid_auth_login_enabled', FALSE);
+
+  if ($login_enabled) {
+    return drupal_get_form($form_id);
+  }
+  drupal_access_denied();
+
 }

--- a/hid_auth.module
+++ b/hid_auth.module
@@ -12,6 +12,28 @@ include_once 'hid_auth.features.inc';
 function hid_auth_menu_alter(&$items) {
   // Disable the user registration page for all users.
   $items['user/register']['access callback'] = FALSE;
+
+  // Disable the user login page if disabled.
+  $items['user']['page callback'] = 'hid_auth_user_page';
+  $items['user/login']['access callback'] = 'hid_auth_user_is_anonymous';
+}
+
+/**
+ * Implements hook_menu()).
+ */
+function hid_auth_menu() {
+  $items = array();
+
+  $items['admin/config/services/hid_auth'] = array(
+    'title'             => 'Humanitarian ID',
+    'description'       => 'Configure the Humanitarian ID app integration with this site.',
+    'page callback'     => 'drupal_get_form',
+    'page arguments'    => array('hid_auth_configpage'),
+    'access arguments'  => array('administer users'),
+    'file'              => 'hid_auth.admin.inc',
+  );
+
+  return $items;
 }
 
 /**
@@ -165,4 +187,32 @@ function hid_auth_api_post($resource_path, $data = array()) {
   $variables['endpoint'] = $base_url;
 
   return restclient_post($resource_path, $variables);
+}
+
+/**
+ * Access callback function to replace user_is_anonymous(). If logins are 
+ * disabled, deny the user automatically. Otherwise, continue on to the
+ * original user_is_anonymous() callback.
+ */
+function hid_auth_user_is_anonymous() {
+  $login_enabled = variable_get('hid_auth_login_enabled', FALSE);
+  if ($login_enabled) {
+    return user_is_anonymous();
+  }
+  return FALSE;
+}
+
+/**
+ * Callback function to replace user_page(). If logins are not permitted and
+ * the user is not logged in, deny the user access. If the user is logged in,
+ * display their user page.
+ */
+function hid_auth_user_page() {
+  global $user;
+  $login_enabled = variable_get('hid_auth_login_enabled', FALSE);
+
+  if ($user->uid || $login_enabled) { // the order is important here
+    return user_page();
+  }
+  drupal_access_denied();
 }


### PR DESCRIPTION
This change disables /user/password and /user/login paths by default, and this behavior can be overridden by setting the 'hid_auth_login_enabled' system variable to TRUE using 'drush vset hid_auth_login_enabled 1' or using the admin UI at /admin/config/services/hid_auth. This also disables the user login form at /user, but will still display the user page for a logged-in user.
